### PR TITLE
Add parent ID to event batch with errors

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-release_version = 2.0.0
+release_version = 2.0.1
 
 docker_image_name=

--- a/src/main/java/com/exactpro/th2/codec/csv/CsvCodec.java
+++ b/src/main/java/com/exactpro/th2/codec/csv/CsvCodec.java
@@ -191,7 +191,8 @@ public class CsvCodec implements MessageListener<RawMessageBatch> {
 
     private void reportErrors(List<ErrorHolder> errors) {
         try {
-            EventBatch.Builder errorBatch = EventBatch.newBuilder();
+            EventBatch.Builder errorBatch = EventBatch.newBuilder()
+                    .setParentEventId(rootId);
             for (ErrorHolder error : errors) {
                 errorBatch.addEvents(
                         Event.start()


### PR DESCRIPTION
The codec doesn't add the parent ID to the entire batch. That causes the error when the estore tries to store that batch